### PR TITLE
Make navigation bar sticky only when screen size permits

### DIFF
--- a/meal_planner/ui/layout.py
+++ b/meal_planner/ui/layout.py
@@ -52,7 +52,7 @@ def sidebar():
         ),
         uk_nav=True,
         cls=NavT.primary,
-        uk_sticky="offset: 20",
+        uk_sticky="offset: 20; media: @m",
     )
     return Div(nav, cls="space-y-4 p-4 w-full md:w-full")
 
@@ -92,6 +92,7 @@ def with_layout(title: str, *content):
         sidebar(),
         id="mobile-sidebar",
         hidden=True,
+        cls="md:!hidden",
     )
 
     github_link = Div(


### PR DESCRIPTION
## Pull Request Checklist

- [ ] App functionality has been confirmed manually (https://gsganden--meal-planner-web-dev.modal.run/)
- [ ] Dark mode has been checked manually
- [ ] Mobile UI has been checked manually
- [ ] Excessive comments have been removed
- [ ] `README.md` has been updated
