### PR TITLE
Remove duplicate recipe title on recipe pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://github.com/gsganden/meal_planner/actions/workflows/ci_cd.yml/badge.svg)](https://github.com/gsganden/meal_planner/actions/workflows/ci_cd.yml)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Checked with Pyright](https://img.shields.io/badge/type_checked-pyright-blue)](https://github.com/microsoft/pyright)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 
 # Meal Planner

--- a/meal_planner/routers/pages.py
+++ b/meal_planner/routers/pages.py
@@ -163,4 +163,4 @@ async def get_single_recipe_page(recipe_id: str):
         title = recipe_data["name"]
         content = build_recipe_display(recipe_data)
 
-    return with_layout(title, content)
+    return with_layout(title, content, show_title=False)

--- a/meal_planner/ui/layout.py
+++ b/meal_planner/ui/layout.py
@@ -57,7 +57,7 @@ def sidebar():
     return Div(nav, cls="space-y-4 p-4 w-full md:w-full")
 
 
-def with_layout(title: str, *content):
+def with_layout(title: str, *content, show_title: bool = True):
     """Wrap content in the standard application layout.
 
     Provides consistent page structure with sidebar navigation, header,
@@ -65,9 +65,11 @@ def with_layout(title: str, *content):
     application's standard layout components.
 
     Args:
-        title: Page title to display in browser tab and header.
+        title: Page title to display in browser tab and optionally as H1 header.
         *content: Variable number of FastHTML components to render
             in the main content area.
+        show_title: Whether to display the title as H1 in the content area.
+            Defaults to True for backward compatibility.
 
     Returns:
         Complete HTML page with layout wrapper and provided content.
@@ -116,7 +118,7 @@ def with_layout(title: str, *content):
         Div(cls="flex flex-col md:flex-row w-full")(
             Div(sidebar(), cls="hidden md:block w-1/5 max-w-52"),
             Div(
-                H1(title, cls="text-3xl font-bold mb-6"),
+                H1(title, cls="text-3xl font-bold mb-6") if show_title else None,
                 *content,
                 cls="md:w-4/5 w-full p-4",
                 id="content",


### PR DESCRIPTION
## Summary
- Added `show_title` parameter to `with_layout()` function to control H1 title visibility
- Recipe pages now only show the title in the browser tab and inside the recipe card
- Removed Pyright badge from README since it's not being used

## Test plan
- [x] Navigate to any recipe page and verify the title appears only once (inside the recipe card)
- [x] Verify the browser tab still shows the recipe name
- [x] Check that other pages still display their H1 titles normally
- [x] Ensure no regressions in layout or navigation

🤖 Generated with [Claude Code](https://claude.ai/code)